### PR TITLE
Fix issue #4 : Buffer instead of String in contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function plugin(options) {
       });
 
       if (foundMatches) { // only do anything to contents, if matches were found
-        files[file].contents = $.html();
+        files[file].contents = new Buffer($.html());
       }
 
     });


### PR DESCRIPTION
Fix issue #4 https://github.com/majodev/metalsmith-data-markdown/issu…

Save contents as buffer instead of string after transform.
